### PR TITLE
Composerize the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .DS_Store?
 .idea
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "procinger/magento-wso2-saml",
+    "description": "Basic Magento login/logout WSO2 Identity Server SAML module",
+    "type": "magento-module"
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,3 @@
+Magento/app/code/community/Hukmedia/        app/code/community/Hukmedia
+Magento/app/etc/modules/Hukmedia_Wso2.xml   app/etc/modules/Hukmedia_Wso2.xml
+Magento/lib/OneLogin/                       lib/OneLogin


### PR DESCRIPTION
Add the possibility to install the module via composer using a Magento composer installer. 
Tested with the [Bragento/Magento Composer Installer](https://github.com/bragento/magento-composer-installer/)